### PR TITLE
Only read file attributes once when creating Directory or ArchivePathTree

### DIFF
--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedDependency.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/maven/dependency/ResolvedDependency.java
@@ -2,12 +2,10 @@ package io.quarkus.maven.dependency;
 
 import io.quarkus.bootstrap.workspace.ArtifactSources;
 import io.quarkus.bootstrap.workspace.WorkspaceModule;
-import io.quarkus.paths.DirectoryPathTree;
 import io.quarkus.paths.EmptyPathTree;
 import io.quarkus.paths.MultiRootPathTree;
 import io.quarkus.paths.PathCollection;
 import io.quarkus.paths.PathTree;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 public interface ResolvedDependency extends Dependency {
@@ -40,12 +38,12 @@ public interface ResolvedDependency extends Dependency {
         }
         if (paths.isSinglePath()) {
             final Path p = paths.getSinglePath();
-            return Files.isDirectory(p) ? new DirectoryPathTree(p) : PathTree.ofArchive(p);
+            return PathTree.ofDirectoryOrArchive(p);
         }
         final PathTree[] trees = new PathTree[paths.size()];
         int i = 0;
         for (Path p : paths) {
-            trees[i++] = Files.isDirectory(p) ? new DirectoryPathTree(p) : PathTree.ofArchive(p);
+            trees[i++] = PathTree.ofDirectoryOrArchive(p);
         }
         return new MultiRootPathTree(trees);
     }

--- a/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTree.java
+++ b/independent-projects/bootstrap/app-model/src/main/java/io/quarkus/paths/PathTree.java
@@ -1,7 +1,9 @@
 package io.quarkus.paths;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collection;
 import java.util.function.Function;
 import java.util.jar.Manifest;
@@ -9,13 +11,29 @@ import java.util.jar.Manifest;
 public interface PathTree {
 
     static PathTree of(Path p) {
-        if (Files.isDirectory(p)) {
-            return new DirectoryPathTree(p);
-        }
-        if (Files.exists(p)) {
+        try {
+            BasicFileAttributes fileAttributes = Files.readAttributes(p, BasicFileAttributes.class);
+            if (fileAttributes.isDirectory()) {
+                return new DirectoryPathTree(p);
+            }
+
             return new FilePathTree(p);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(p + " does not exist");
         }
-        throw new IllegalArgumentException(p + " does not exist");
+    }
+
+    static PathTree ofDirectoryOrArchive(Path p) {
+        try {
+            BasicFileAttributes fileAttributes = Files.readAttributes(p, BasicFileAttributes.class);
+            if (fileAttributes.isDirectory()) {
+                return new DirectoryPathTree(p);
+            }
+
+            return new ArchivePathTree(p);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(p + " does not exist");
+        }
     }
 
     static PathTree ofArchive(Path archive) {

--- a/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassPathElement.java
+++ b/independent-projects/bootstrap/core/src/main/java/io/quarkus/bootstrap/classloading/ClassPathElement.java
@@ -2,12 +2,10 @@ package io.quarkus.bootstrap.classloading;
 
 import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.ResolvedDependency;
-import io.quarkus.paths.DirectoryPathTree;
 import io.quarkus.paths.EmptyPathTree;
 import io.quarkus.paths.OpenPathTree;
 import io.quarkus.paths.PathTree;
 import java.io.Closeable;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.ProtectionDomain;
 import java.util.Collections;
@@ -81,7 +79,7 @@ public interface ClassPathElement extends Closeable {
      * Creates an element from a file system path
      */
     static ClassPathElement fromPath(Path path, boolean runtime) {
-        return new PathTreeClassPathElement(Files.isDirectory(path) ? new DirectoryPathTree(path) : PathTree.ofArchive(path),
+        return new PathTreeClassPathElement(PathTree.ofDirectoryOrArchive(path),
                 runtime);
     }
 


### PR DESCRIPTION
Avoids doing a `Files.exists(Path)` call, when previously a `Files.isDirectory(Path)` call was made.
Files.readAttributes, which was called internally by `isDirectory` anyway, throws a FileNotFoundException when a file does not exists.

Saves us doing this call just to check for existence:
![Unbenannt](https://user-images.githubusercontent.com/1223135/147704328-8054676d-196a-482b-8028-d49dfafeb7b4.png)

Saves about 5ms of dev mode startup time for me on windows.